### PR TITLE
feat: Add proper support for multiple outputs of elisp packages

### DIFF
--- a/pkgs/emacs/default.nix
+++ b/pkgs/emacs/default.nix
@@ -11,6 +11,7 @@
 , addSystemPackages ? true
 , inputOverrides ? { }
 , nativeCompileAheadDefault ? true
+, extraOutputsToInstall ? [ "info" "doc" ]
 }:
 let
   inherit (builtins) readFile attrNames attrValues concatLists isFunction
@@ -119,6 +120,7 @@ in
           if addSystemPackages
           then lib.attrVals (userConfig.systemPackages or [ ]) final
           else [ ];
+        inherit extraOutputsToInstall;
       };
 
     # This makes the attrset a derivation for a shorthand.

--- a/pkgs/emacs/wrapper.nix
+++ b/pkgs/emacs/wrapper.nix
@@ -7,6 +7,7 @@
 , texinfo
 , elispInputs
 , executablePackages
+, extraOutputsToInstall
 }:
 let
   inherit (builtins) length;
@@ -21,7 +22,7 @@ let
       "/share/info"
       "/share/doc"
     ] ++ lib.optional nativeComp "/share/emacs/native-lisp";
-    extraOutputsToInstall = [ "info" "doc" ];
+    inherit extraOutputsToInstall;
     buildInputs = [
       texinfo
     ];


### PR DESCRIPTION
Some packages failed to build info, and there needs to be a proper way to specify outputs.

With this PR, you can override the outputs of a particular package:

```nix
  sml-mode = esuper.sml-mode.overrideAttrs (old: {
    outputs = [ "out" ];
  });
```

The above example skips the build step of info, which would fail by default.

It is now also possible to override the command for building the info document of a particular package.