### PR TITLE
fix: Exclude fdl.info

### DIFF
--- a/pkgs/emacs/build/default.nix
+++ b/pkgs/emacs/build/default.nix
@@ -151,7 +151,8 @@ stdenv.mkDerivation (rec {
   installInfo = ''
     mkdir -p $info/share
     install -d $info/share/info
-    rm -f gpl.info contributors.info
+    # Exclude files that can conflict across multiple packages.
+    rm -f gpl.info contributors.info fdl.info
     for i in *.info
     do
       install -t $info/share/info $i


### PR DESCRIPTION
This file describes the GNU Free Documentation License and has the same content as the following URL: https://www.gnu.org/licenses/fdl-1.3.html

It can conflict, so I will remove the file from the output.